### PR TITLE
Add run_and_get_stdout function

### DIFF
--- a/ck/kernel.py
+++ b/ck/kernel.py
@@ -514,6 +514,35 @@ def system_with_timeout(i):
     return {'return':0, 'return_code':rc}
 
 ##############################################################################
+# Run command and get stdout
+
+def run_and_get_stdout(i):
+  """
+  Input:  {
+            cmd       - list of command line arguments, starting with the command itself
+          }
+
+  Output: {
+            return       - return code =  0, if successful
+                                       >  0, if error
+                                       =  8, if timeout
+            (error)      - error text if return > 0
+
+            return_code  - return code from app
+
+            stdout       - string, standard output of the command
+          }
+  """
+
+  import subprocess
+
+  p1 = subprocess.Popen(i['cmd'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  output = p1.communicate()[0]
+  if sys.version_info[0]>2:
+    output = output.decode(encoding='UTF-8')
+  return {'return':0, 'return_code':p1.returncode, 'stdout':output}
+
+##############################################################################
 # Get value from one dict, remove it from there and move to another
 
 def get_from_dicts(dict1, key, default_value, dict2, extra=''):


### PR DESCRIPTION
Hi,

This PR adds a new function to the kernel: run_and_get_stdout. The function runs a command and returns its standard output as a string. I needed this feature to make ck-env's detect in platform.cpu work with OS X (the PR for that follows shortly) and thought it would be nice to have it as a part of general API.