### PR TITLE
Integrate with Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/*
 MANIFEST
 *.pyc
 __pycache__
+.cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.5-dev" # 3.5 development branch
+  - "nightly" # currently points to 3.6-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ python:
 # skip the install step for now
 install: true
 
-script: py.test ck
+script: py.test -v ck

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ python:
 # skip the install step for now
 install: true
 
-script: pytest ck
+script: py.test ck

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,8 @@ python:
   - "3.5"
   - "3.5-dev" # 3.5 development branch
   - "nightly" # currently points to 3.6-dev
+
+# skip the install step for now
+install: true
+
+script: pytest ck

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/dsavenko/ck.svg?branch=master)](https://travis-ci.org/dsavenko/ck)
+
 Introduction
 ============
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/dsavenko/ck.svg?branch=master)](https://travis-ci.org/dsavenko/ck)
+[![Build Status](https://travis-ci.org/ctuning/ck.svg?branch=master)](https://travis-ci.org/ctuning/ck)
 
 Introduction
 ============

--- a/ck/test_kernel.py
+++ b/ck/test_kernel.py
@@ -1,0 +1,11 @@
+
+import ck.kernel as ck
+
+def test_safe_float():
+    import math
+
+    assert ck.safe_float(1, 0) == 1.0
+    assert ck.safe_float('a', 0) == 0
+    assert ck.safe_float('-5.35', 0) == -5.35
+    assert ck.safe_float('Infinity', 0) == float('inf')
+    assert math.isnan(ck.safe_float('nan', 0))


### PR DESCRIPTION
Hi,

This PR adds integration with travis-ci.org. You can check the Travis build for the fork to see how it looks: https://travis-ci.org/dsavenko/ck . 

I added one very simple test ('test_safe_float'), because without any tests Travis build is next to useless. This test and the 'tests/' folder should be refactored in subsequent PRs about testing. 

After merging, you need to log in travis-ci.org and enable travis for the CK repository.

P.S. The button is README doesn't look as intended yet, because I changed the URL to the future URL of the upstream travis build, which doesn't yet exist. It should start working as soon as you enable Travis for the project. 