### PR TITLE
Measure code coverage by tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ MANIFEST
 *.pyc
 __pycache__
 .cache/
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: python
 python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.5-dev" # 3.5 development branch
-  - "nightly" # currently points to 3.6-dev
+    - "2.7"
+    - "3.3"
+    - "3.4"
+    - "3.5"
+    - "3.5-dev" # 3.5 development branch
+    - "nightly" # currently points to 3.6-dev
 
 # skip the install step for now
-install: true
+install: pip install coveralls
 
-script: python -m tests.test
+script: coverage run -m tests.test
+
+after_success: coveralls

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/ctuning/ck.svg?branch=master)](https://travis-ci.org/ctuning/ck)
-[![Coverage Status](https://coveralls.io/repos/github/dsavenko/ck/badge.svg?branch=coverage)](https://coveralls.io/github/dsavenko/ck?branch=coverage)
+[![Coverage Status](https://coveralls.io/repos/github/ctuning/ck/badge.svg)](https://coveralls.io/github/ctuning/ck)
 
 Introduction
 ============

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/ctuning/ck.svg?branch=master)](https://travis-ci.org/ctuning/ck)
+[![Coverage Status](https://coveralls.io/repos/github/dsavenko/ck/badge.svg?branch=coverage)](https://coveralls.io/github/dsavenko/ck?branch=coverage)
 
 Introduction
 ============


### PR DESCRIPTION
Hi,

This PR enables code coverage measurement by tests. It uses the [Coveralls](http://coveralls.io/) service, which is free for open source projects. 

After merging, you need to log in [Coveralls](http://coveralls.io/) with the cTuning github account. It asks you to select payment plan — **you can skip this step**. Just move mouse to the left (where the menu is) and choose 'Add repo'. 

A list of your github repos appear. Select 'on' for CK. That's it!

You may need to build the repo again in travis. After that you can navigate to https://coveralls.io/github/ctuning/ck and check the coverage as well as detailed reports on which lines are covered.

The PR also adds the 'coverage' badge to README (next to the 'build' badge).

**Warning! This PR depends on the 'tests' [PR](https://github.com/ctuning/ck/pull/54) and should not be merged before that one.**