### PR TITLE
Continuous integration for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/ctuning/ck.svg?branch=master)](https://travis-ci.org/ctuning/ck)
+[![Windows Build status](https://ci.appveyor.com/api/projects/status/github/ctuning/ck?svg=true)](https://ci.appveyor.com/project/ctuning/ck)
 
 NEWS
 ====

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,20 @@
+environment:
+
+  matrix:
+
+    # For Python versions available on Appveyor, see
+    # http://www.appveyor.com/docs/installed-software#python
+
+    - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python33"
+    - PYTHON: "C:\\Python34"
+    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python33-x64"
+    - PYTHON: "C:\\Python34-x64"
+    - PYTHON: "C:\\Python35-x64"
+
+build: false
+
+test_script:
+  - "%PYTHON%\\python.exe -m tests.test"


### PR DESCRIPTION
Hi,

This PR enables continuous integration on Windows. 

Travis-CI does not support Windows, so this PR makes use of [AppVeyor](https://www.appveyor.com/), which is similar to Travis, but for Windows.

After merging you need to log in [AppVeyor](https://www.appveyor.com/) with the `ctuning` account and add CK project. May be, you'll need to initiate a single build for everything to work.