### PR TITLE
Improve tests failure reporting, fix Windows tests

### DIFF
--- a/ck/repo/module/kernel/test/test_kernel.py
+++ b/ck/repo/module/kernel/test/test_kernel.py
@@ -375,22 +375,24 @@ class TestKernel(unittest.TestCase):
             with open(fname + '/b/test.log', 'a') as f:
                 f.write('12')
 
+            s = os.sep
+
             r = ck.list_all_files({'path': fname, 'limit': 10})
             self.assertEqual(0, r['return'])
             t = r['list']
-            self.assertEqual({'size': 3}, t['a/test.txt'])
-            self.assertEqual({'size': 2}, t['b/test.log'])
+            self.assertEqual({'size': 3}, t['a' + s + 'test.txt'])
+            self.assertEqual({'size': 2}, t['b' + s + 'test.log'])
 
             r = ck.list_all_files({'path': fname, 'pattern': '*.txt'})
             self.assertEqual(0, r['return'])
             t = r['list']
-            self.assertEqual({'size': 3}, t['a/test.txt'])
-            self.assertEqual(None, t.get('b/test.log'))
+            self.assertEqual({'size': 3}, t['a' + s + 'test.txt'])
+            self.assertEqual(None, t.get('b' + s + 'test.log'))
 
             r = ck.list_all_files({'path': fname, 'file_name': 'test.txt'})
             self.assertEqual(0, r['return'])
             t = r['list']
-            self.assertEqual({'size': 3}, t['a/test.txt'])
+            self.assertEqual({'size': 3}, t['a' + s + 'test.txt'])
 
         with test_util.tmp_dir() as fname:
             with open(fname + '/test.txt', 'a') as f:
@@ -664,9 +666,17 @@ class TestKernel(unittest.TestCase):
         self.assertIn('path', r)
 
     def test_cd(self):
+        r = ck.get_os_ck({})
+        plat = r['platform']
+
         r = ck.cd({'module_uoa': 'kernel', 'data_uoa': 'default'})
         self.assertEqual(0, r['return'])
-        self.assertEqual('cd ' + r['path'], r['string'])
+
+        if plat == 'win':
+            self.assertEqual('cd /D ' + r['path'], r['string'])
+        else:
+            self.assertEqual('cd ' + r['path'], r['string'])
+
         # check for fields from ck.find:
         self.assertEqual(1, r['number_of_entries'])
         self.assertEqual('kernel', r['module_uoa'])
@@ -745,9 +755,11 @@ class TestKernel(unittest.TestCase):
         self.assertEqual('no', r['found'])
 
     def test_list_files(self):
+        s = os.sep
+
         r = ck.list_files({'repo_uoa': 'default', 'module_uoa': 'module', 'data_uoa': 'kernel'})
         self.assertEqual(0, r['return'])
         lst = r['list']
         self.assertIn('module.py', lst)
-        self.assertIn('test/test_kernel.py', lst)
-        self.assertIn('test/test_original_tests.py', lst)
+        self.assertIn('test' + s + 'test_kernel.py', lst)
+        self.assertIn('test' + s + 'test_original_tests.py', lst)

--- a/ck/repo/module/kernel/test/test_kernel.py
+++ b/ck/repo/module/kernel/test/test_kernel.py
@@ -669,26 +669,27 @@ class TestKernel(unittest.TestCase):
         r = ck.get_os_ck({})
         plat = r['platform']
 
-        r = ck.cd({'module_uoa': 'kernel', 'data_uoa': 'default'})
-        self.assertEqual(0, r['return'])
+        with test_util.tmp_sys():
+            r = ck.cd({'module_uoa': 'kernel', 'data_uoa': 'default'})
+            self.assertEqual(0, r['return'])
 
-        if plat == 'win':
-            self.assertEqual('cd /D ' + r['path'], r['string'])
-        else:
-            self.assertEqual('cd ' + r['path'], r['string'])
+            if plat == 'win':
+                self.assertEqual('cd /D ' + r['path'], r['string'])
+            else:
+                self.assertEqual('cd ' + r['path'], r['string'])
 
-        # check for fields from ck.find:
-        self.assertEqual(1, r['number_of_entries'])
-        self.assertEqual('kernel', r['module_uoa'])
-        self.assertEqual('kernel', r['module_alias'])
-        self.assertEqual('default', r['data_uoa'])
-        self.assertEqual('local', r['repo_alias'])
-        self.assertEqual('local', r['repo_uoa'])
-        self.assertIn('repo_uid', r)
-        self.assertIn('module_uid', r)
-        self.assertIn('data_uid', r)
-        self.assertIn('path_repo', r)
-        self.assertIn('path', r)
+            # check for fields from ck.find:
+            self.assertEqual(1, r['number_of_entries'])
+            self.assertEqual('kernel', r['module_uoa'])
+            self.assertEqual('kernel', r['module_alias'])
+            self.assertEqual('default', r['data_uoa'])
+            self.assertEqual('local', r['repo_alias'])
+            self.assertEqual('local', r['repo_uoa'])
+            self.assertIn('repo_uid', r)
+            self.assertIn('module_uid', r)
+            self.assertIn('data_uid', r)
+            self.assertIn('path_repo', r)
+            self.assertIn('path', r)
 
     def test_search(self):
         r = ck.search({'repo_uoa': 'default', 'module_uoa': 'kernel'})

--- a/ck/repo/module/kernel/test/test_mgmt.py
+++ b/ck/repo/module/kernel/test/test_mgmt.py
@@ -168,7 +168,7 @@ class TestMgmt(unittest.TestCase):
             self.assertEqual(32, r['return'])
             self.assertEqual('entry is locked with different UID', r['error'])
 
-            time.sleep(1)
+            time.sleep(2)
             r = ck.check_lock({'path': path, 'unlock_uid': lock_uid + '1'})
             self.assertEqual(32, r['return'])
             self.assertEqual('entry lock UID is not matching', r['error'])


### PR DESCRIPTION
Hi,

This PR improves tests failure reporting. With it, `ck run test` return code depends on the number of failed tests. Previously, it returned 0 even if there were failed tests, which made it hard to use in shell scripts. Now, it returns 0, if all tests passed. If some tests failed, it returns `100 + number of failed tests`. Return codes in between 1 and 100 are reserved for test execution errors. 

So, with this PR, the caller can easily detect if some tests failed, distinguish this case from the case when test execution failed, and even detect, how many tests failed, just by the return code, without parsing the command output.

Also, this PR fixes some tests, which were failing under Windows (#63).