### PR TITLE
Fix unorderable types error on 'ck status'

### DIFF
--- a/ck/kernel.py
+++ b/ck/kernel.py
@@ -4386,6 +4386,16 @@ def check_version(i):
 
         lversion[q]=xx
 
+    def parseint(val):
+        if type(val) is str:
+            return int(''.join([x for x in val if x.isdigit()]))
+        else:
+            return val
+
+    for i in range(len(version)):
+        lversion[i] = parseint(lversion[i])
+        version[i] = parseint(version[i])
+
     if lversion[0]>version[0] or \
        (lversion[0]==version[0] and lversion[1]>version[1]) or \
        (lversion[0]==version[0] and lversion[1]==version[1] and lversion[2]>version[2]):


### PR DESCRIPTION
Running 'ck status' on development version throws a TypeError due to
the micro version being a string:

    $ ck status
    Traceback (most recent call last):
      ...
      File ".../lib/python3.5/site-packages/ck/kernel.py", line 4309, in status
        rx=check_version({'version':lversion_str})
      File ".../lib/python3.5/site-packages/ck/kernel.py", line 4389, in check_version
        (lversion[0]==version[0] and lversion[1]==version[1] and lversion[2]>version[2]):
    TypeError: unorderable types: str() > int()

This patches fixes this by first casting version compoments to
integers, ignoring the 'dev' suffix (if present):

    $ ck status
    Your version is up-to-date: V1.8.3dev

Tested on:

    $ python --version
    Python 3.5.2