### PR TITLE
added 'default_action_name' key to module's .cm/meta.json to allow intercepting any undefined method

### DIFF
--- a/ck/kernel.py
+++ b/ck/kernel.py
@@ -3428,6 +3428,7 @@ def perform_action(i):
 
        declared_action      = action in u.get('actions',{})
        default_action_name  = u.get('default_action_name','')
+       intercept_kernel     = i.get('{}.intercept_kernel'.format(module_uoa),'')
 
        if declared_action or default_action_name:
           # Load module
@@ -3451,9 +3452,14 @@ def perform_action(i):
           if wb=='yes' and (out=='con' or out=='web') and u.get('actions',{}).get(action,{}).get('for_web','')!='yes':
              return {'return':1, 'error':'this action is not supported in remote/web mode'}
 
-          if declared_action:   # otherwise fall through and try a "special" kernel method first
+          if declared_action:
               a=getattr(loaded_module, action1)
               return a(i)
+          elif default_action_name and intercept_kernel:
+              a=getattr(loaded_module, default_action_name)
+              return a(i)
+          # otherwise fall through and try a "special" kernel method first
+
 
     # Check if action == special keyword (add, delete, list, etc)
     if (module_uoa!='' and action in cfg['common_actions']) or \


### PR DESCRIPTION
This pull request deals with the situation when an action is missing from the module's .cm/meta.json declaration dictionary.

The old behaviour was to immediately return with an error, stating that the method is unavailable.

The new proposed behaviour is to also check if the module has a 'default_action_name' defined. If it is defined and the corresponding function exists, this default function will be called instead.

If the 'default_action_name' is not defined, the behaviour is exactly the same as it used to be (an error is generated).

The new behaviour opens a new dimension for extending CK by allowing a CK module to intercept calls to another module, augmenting or substituting the functionality.